### PR TITLE
Change order of routes from specific to broad

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,9 +70,6 @@ mongoose.connect("mongodb+srv://slsmi285:Florida89!@cluster0.upwzp.mongodb.net/p
 );
 
 // // Local API for hardcoded infostate 
-app.use(routes);
-
-
 
     //Routes - passport 
     app.post("/login", (req, res, next) => {
@@ -114,6 +111,8 @@ app.use(routes);
     app.get("/user", (req, res) => {
         res.send(req.User);//The req.user stores the entire user that has been authenticated inside of it, has all the session data
     });
+
+    app.use(routes);
     // end of Routes
 
 


### PR DESCRIPTION
@slsmi285 @KATHERINERSL

Ladies, as you can see all I did was change the location of when the routes are introduced into the application. Remember that you want to think of a series of nets when defining your routes in a specific order. You want to place the more specific routes (smaller net) first and the more broad (wider net) towards the end. In this case since `routes` was first, it thought the `/register' route was an html file.

Hope this helps!